### PR TITLE
fix(luasnip): use stdpath for snippet paths

### DIFF
--- a/nvim/.config/nvim/lua/custom/plugins/luasnip.lua
+++ b/nvim/.config/nvim/lua/custom/plugins/luasnip.lua
@@ -4,7 +4,7 @@ return {
   build = "make install_jsregexp",
   event = "InsertEnter",
   config = function()
-    require("luasnip.loaders.from_lua").lazy_load({ paths = "./lua/luasnip/" })
+    require("luasnip.loaders.from_lua").lazy_load({ paths = vim.fn.stdpath("config") .. "/lua/luasnip/" })
     local ls = require("luasnip")
     ls.setup({
       update_events = { "TextChanged", "TextChangedI" },


### PR DESCRIPTION
## Summary
- ensure LuaSnip snippet loader uses `vim.fn.stdpath("config")` for reliable path resolution

## Testing
- `luac -p nvim/.config/nvim/lua/custom/plugins/luasnip.lua`


------
https://chatgpt.com/codex/tasks/task_e_68a4458f64f88327a86d304462588ae3